### PR TITLE
fix: 组件重复展示时, useMouseHover.tsx 不起作用

### DIFF
--- a/src/hooks/useMouseHover.tsx
+++ b/src/hooks/useMouseHover.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import type { RefObject } from 'react';
 
@@ -14,8 +14,19 @@ export default function useHover<T extends HTMLElement = HTMLElement>(
     setValue(false);
   };
 
-  elementRef.current?.addEventListener('mouseenter', handleMouseEnter);
-  elementRef.current?.addEventListener('mouseleave', handleMouseLeave);
+  useEffect(() => {
+    const node = elementRef?.current;
+    if (node) {
+      node.addEventListener('mouseenter', handleMouseEnter);
+      node.addEventListener('mouseleave', handleMouseLeave);
+    }
+    return () => {
+      if (node) {
+        node.removeEventListener('mouseenter', handleMouseEnter);
+        node.removeEventListener('mouseleave', handleMouseLeave);
+      }
+    };
+  }, [elementRef.current]);
 
   return value;
 }


### PR DESCRIPTION
使用了 useEffect 来处理事件监听器的添加和移除。这样可以确保：
当组件显示（挂载）时，mouseenter 和 mouseleave 事件监听器会被添加到对应的元素上。   
当组件消失（卸载）时，这些事件监听器会被自动清理，避免了内存泄漏和潜在的 bug。   
当 elementRef.current 变化时（例如组件重新渲染后 ref 指向了新的 DOM 元素），useEffect 会重新执行，为新的元素正确地挂载事件。